### PR TITLE
Update Beginner Resources.md - ZAP no longer an OWASP project

### DIFF
--- a/Beginner Resources.md
+++ b/Beginner Resources.md
@@ -88,4 +88,4 @@ List to be updated as I find helpful books and blog posts.
 ## Other useful links
 - Home Lab and CTF https://benheater.com/
 	- Ben's site can be very useful through your entire journey. Explore his material well, do not skip. If you decided on going the route of setting up your own home lab then extra don't skip.
-- Burpsuite Pro is great, but the free version has it's limitations. For unthrottled fuzzing and vulnerability scanning OWASP ZAP is an amazing free alternative https://www.zaproxy.org/ I've linked this here because while Hack the Box Academy covers ZAP, many other courses don't.
+- Burpsuite Pro is great, but the free version has it's limitations. For unthrottled fuzzing and vulnerability scanning ZAP is an amazing free alternative https://www.zaproxy.org/ I've linked this here because while Hack the Box Academy covers ZAP, many other courses don't.


### PR DESCRIPTION
ZAP left OWASP about a year ago.